### PR TITLE
Add Auto Release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release with upstream
+
+on:
+  workflow_dispatch:  # Allow manual triggers
+  push:
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update repo
+      run: |
+        . ./update.sh
+        echo "version=${VLATEST:1}" >> $GITHUB_ENV
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        commit_message: Bump KS version ${{ env.version }}

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,9 @@
+git clone https://github.com/kubescape/kubescape.git --no-checkout
+cd kubescape
+export VLATEST=$(git describe --tags --abbrev=0)
+cd ..
+rm -rf kubescape
+wget https://github.com/kubescape/kubescape/archive/${VLATEST}.tar.gz
+sed -i "s#kubescape/archive/.*#kubescape/archive/${VLATEST}.tar.gz\"#g" kubescape-cli.rb
+sed -i "s/^  sha256 \".*/  sha256 \"$(sha256sum ${VLATEST}.tar.gz | cut -d' ' -f1)\"/g" kubescape-cli.rb
+rm -rf ${VLATEST}.tar.gz


### PR DESCRIPTION
Allow auto bumping the kubescape version through CI. Later will cooperate with the main release workflow at kubescape main repo to allow a fully automated release.